### PR TITLE
Update Package.swift to be in sync with Engine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     platforms: [
         .iOS(.v13),
         .macCatalyst(.v13),
+        .macOS(.v10_15),
 //        .visionOS(.v1),
     ],
     products: [


### PR DESCRIPTION
Include `.macOS(.v10_15)` so that this target has the same requirement as Engine.