### PR TITLE
chore: resolve build errors when compiling for swift 6.2

### DIFF
--- a/Example/Example/DynamicIslandTransition.swift
+++ b/Example/Example/DynamicIslandTransition.swift
@@ -187,13 +187,15 @@ class DynamicIslandPresentationControllerTransition: PresentationControllerTrans
             }
         }
         animator.addCompletion { animatingPosition in
-            hostingController?.disableSafeArea = oldValue
-            presented.view.layoutIfNeeded()
-            switch animatingPosition {
-            case .end:
-                transitionContext.completeTransition(true)
-            default:
-                transitionContext.completeTransition(false)
+            Task { @MainActor in
+                hostingController?.disableSafeArea = oldValue
+                presented.view.layoutIfNeeded()
+                switch animatingPosition {
+                case .end:
+                    transitionContext.completeTransition(true)
+                default:
+                    transitionContext.completeTransition(false)
+                }
             }
         }
     }

--- a/Sources/Transmission/Sources/Transitions/DestinationLink Transitions/PushDestinationLinkTransition.swift
+++ b/Sources/Transmission/Sources/Transitions/DestinationLink Transitions/PushDestinationLinkTransition.swift
@@ -198,17 +198,19 @@ open class PushNavigationControllerTransition: ViewControllerTransition {
             dimmingView.transform = isPresenting ? fromVCTransform : .identity
         }
         animator.addCompletion { animatingPosition in
-            toVC.view.transform = .identity
-            fromVC.view.transform = .identity
-            dimmingView.removeFromSuperview()
-            if cornerRadius != nil {
-                presentedVC.view.layer.cornerRadius = 0
-            }
-            switch animatingPosition {
-            case .end:
-                transitionContext.completeTransition(true)
-            default:
-                transitionContext.completeTransition(false)
+            Task { @MainActor in
+                toVC.view.transform = .identity
+                fromVC.view.transform = .identity
+                dimmingView.removeFromSuperview()
+                if cornerRadius != nil {
+                    presentedVC.view.layer.cornerRadius = 0
+                }
+                switch animatingPosition {
+                case .end:
+                    transitionContext.completeTransition(true)
+                default:
+                    transitionContext.completeTransition(false)
+                }
             }
         }
     }

--- a/Sources/Transmission/Sources/Transitions/DestinationLink Transitions/SlideDestinationLinkTransition.swift
+++ b/Sources/Transmission/Sources/Transitions/DestinationLink Transitions/SlideDestinationLinkTransition.swift
@@ -152,13 +152,15 @@ open class SlideNavigationControllerTransition: ViewControllerTransition {
             fromVC.view.alpha = initialOpacity
         }
         animator.addCompletion { animatingPosition in
-            toVC.view.transform = .identity
-            fromVC.view.transform = .identity
-            switch animatingPosition {
-            case .end:
-                transitionContext.completeTransition(true)
-            default:
-                transitionContext.completeTransition(false)
+            Task { @MainActor in
+                toVC.view.transform = .identity
+                fromVC.view.transform = .identity
+                switch animatingPosition {
+                case .end:
+                    transitionContext.completeTransition(true)
+                default:
+                    transitionContext.completeTransition(false)
+                }
             }
         }
     }

--- a/Sources/Transmission/Sources/Transitions/Presentation Controllers/SlidePresentationController.swift
+++ b/Sources/Transmission/Sources/Transitions/Presentation Controllers/SlidePresentationController.swift
@@ -210,17 +210,19 @@ open class SlidePresentationControllerTransition: PresentationControllerTransiti
             }
         }
         animator.addCompletion { animatingPosition in
-            if isScaleEnabled {
-                presenting.view.layer.cornerRadius = 0
-                presenting.view.layer.masksToBounds = true
-                presenting.view.transform = .identity
-            }
-            presented.view.layer.cornerRadius = 0
-            switch animatingPosition {
-            case .end:
-                transitionContext.completeTransition(true)
-            default:
-                transitionContext.completeTransition(false)
+            Task { @MainActor in
+                if isScaleEnabled {
+                    presenting.view.layer.cornerRadius = 0
+                    presenting.view.layer.masksToBounds = true
+                    presenting.view.transform = .identity
+                }
+                presented.view.layer.cornerRadius = 0
+                switch animatingPosition {
+                case .end:
+                    transitionContext.completeTransition(true)
+                default:
+                    transitionContext.completeTransition(false)
+                }
             }
         }
     }

--- a/Sources/Transmission/Sources/Transitions/Presentation Controllers/ToastPresentationController.swift
+++ b/Sources/Transmission/Sources/Transitions/Presentation Controllers/ToastPresentationController.swift
@@ -154,11 +154,13 @@ open class ToastPresentationControllerTransition: PresentationControllerTransiti
             }
         }
         animator.addCompletion { animatingPosition in
-            switch animatingPosition {
-            case .end:
-                transitionContext.completeTransition(true)
-            default:
-                transitionContext.completeTransition(false)
+            Task { @MainActor in
+                switch animatingPosition {
+                case .end:
+                    transitionContext.completeTransition(true)
+                default:
+                    transitionContext.completeTransition(false)
+                }
             }
         }
     }

--- a/Sources/Transmission/Sources/Transitions/View Controller Transitions/MatchedGeometryViewControllerTransition.swift
+++ b/Sources/Transmission/Sources/Transitions/View Controller Transitions/MatchedGeometryViewControllerTransition.swift
@@ -245,18 +245,20 @@ open class MatchedGeometryViewControllerTransition: ViewControllerTransition {
         }, delayFactor: isPresenting ? 0 : 0.25)
 
         animator.addCompletion { animatingPosition in
-            hostingController?.disableSafeArea = disableSafeArea
-            presentedPortalView?.removeFromSuperview()
-            if !isPresenting {
-                presentingPortalView?.removeFromSuperview()
-            }
-            sourceView?.alpha = isPresenting ? 0 : 1
-            presented.view.layer.cornerRadius = 0
-            switch animatingPosition {
-            case .end:
-                transitionContext.completeTransition(true)
-            default:
-                transitionContext.completeTransition(false)
+            Task { @MainActor in
+                hostingController?.disableSafeArea = disableSafeArea
+                presentedPortalView?.removeFromSuperview()
+                if !isPresenting {
+                    presentingPortalView?.removeFromSuperview()
+                }
+                sourceView?.alpha = isPresenting ? 0 : 1
+                presented.view.layer.cornerRadius = 0
+                switch animatingPosition {
+                case .end:
+                    transitionContext.completeTransition(true)
+                default:
+                    transitionContext.completeTransition(false)
+                }
             }
         }
     }

--- a/Sources/Transmission/Sources/Transitions/View Controller Transitions/PresentationControllerTransition.swift
+++ b/Sources/Transmission/Sources/Transitions/View Controller Transitions/PresentationControllerTransition.swift
@@ -72,11 +72,13 @@ open class PresentationControllerTransition: ViewControllerTransition {
             }
         }
         animator.addCompletion { animatingPosition in
-            switch animatingPosition {
-            case .end:
-                transitionContext.completeTransition(true)
-            default:
-                transitionContext.completeTransition(false)
+            Task { @MainActor in
+                switch animatingPosition {
+                case .end:
+                    transitionContext.completeTransition(true)
+                default:
+                    transitionContext.completeTransition(false)
+                }
             }
         }
     }

--- a/Sources/Transmission/Sources/Transitions/View Controller Transitions/ViewControllerTransition.swift
+++ b/Sources/Transmission/Sources/Transitions/View Controller Transitions/ViewControllerTransition.swift
@@ -174,11 +174,13 @@ open class ViewControllerTransition: UIPercentDrivenInteractiveTransition, UIVie
             presented.view.alpha = isPresenting ? 1 : 0
         }
         animator.addCompletion { animatingPosition in
-            switch animatingPosition {
-            case .end:
-                transitionContext.completeTransition(true)
-            default:
-                transitionContext.completeTransition(false)
+            Task { @MainActor in
+                switch animatingPosition {
+                case .end:
+                    transitionContext.completeTransition(true)
+                default:
+                    transitionContext.completeTransition(false)
+                }
             }
         }
     }


### PR DESCRIPTION
Hello @nathantannar4. Thanks for this great repo. I tried compiling my project using Xcode 26 with Swift 6.2 and got a number of build errors, such as 

```
Main actor-isolated property 'transform' can not be mutated from a Sendable closure
```

and 
```
Call to main actor-isolated instance method 'completeTransition' in a synchronous nonisolated context
```
in `SlideDestinationLinkTransition.swift` for example

The fix was to wrap the blocks in a `Task` with a `@MainActor` declaration. I've provided this across all the affected files in this PR.