### PR TITLE
Removes extra comma in PresentationSourceViewLink initializer

### DIFF
--- a/Sources/Transmission/Sources/PresentationSourceViewLink.swift
+++ b/Sources/Transmission/Sources/PresentationSourceViewLink.swift
@@ -118,7 +118,7 @@ extension PresentationSourceViewLink {
             transition: transition,
             cornerRadius: cornerRadius,
             backgroundColor: backgroundColor,
-            animation: animation,
+            animation: animation
         ) {
             ViewControllerRepresentableAdapter(destination)
         } label: {


### PR DESCRIPTION
This extra comma is a compiler error