### PR TITLE
Fix TransitionReader linkage error with @State macro (iOS 26 SDK)

### DIFF
--- a/Sources/Transmission/Sources/TransitionReader.swift
+++ b/Sources/Transmission/Sources/TransitionReader.swift
@@ -36,10 +36,6 @@ public struct TransitionReader<Content: View>: View {
 
     @State var proxy = Proxy()
 
-    // Not `@inlinable`: with the iOS 26 SDK `@State` is a macro that synthesizes an
-    // internal init accessor for `proxy`'s default value. An inlinable initializer
-    // cannot reference that internal accessor, producing "Function has wrong linkage
-    // to be called from init(content:)".
     public init(@ViewBuilder content: @escaping (Proxy) -> Content) {
         self.content = content
     }

--- a/Sources/Transmission/Sources/TransitionReader.swift
+++ b/Sources/Transmission/Sources/TransitionReader.swift
@@ -36,7 +36,10 @@ public struct TransitionReader<Content: View>: View {
 
     @State var proxy = Proxy()
 
-    @inlinable
+    // Not `@inlinable`: with the iOS 26 SDK `@State` is a macro that synthesizes an
+    // internal init accessor for `proxy`'s default value. An inlinable initializer
+    // cannot reference that internal accessor, producing "Function has wrong linkage
+    // to be called from init(content:)".
     public init(@ViewBuilder content: @escaping (Proxy) -> Content) {
         self.content = content
     }


### PR DESCRIPTION
### Problem
**Reproducable when Build configuration is set to Release**

Building `Transmission` against the iOS 27 SDK fails to compile in `TransitionReader.swift` with:

```
error: Function has wrong linkage to be called from init(content:)
```

The error originates from the `@State` macro expansion for `TransitionReader.proxy`:

```
@__swiftmacro_12Transmission16TransitionReaderV5proxy5StatefMa_.swift:3: error: Function has wrong linkage to be called from init(content:)
```

### Cause

In the iOS 26 SDK, `@State` migrated from a property wrapper to a **macro**. The macro synthesizes an **internal** init accessor for a property's default value (here, `proxy = Proxy()`).

`TransitionReader.init(content:)` is marked `@inlinable`, which means its body is emitted into client modules and may only reference `public` / `@usableFromInline` symbols. It therefore cannot call `proxy`'s newly-synthesized internal `@State` init accessor — hence the linkage error.

### Fix

Drop `@inlinable` from `init(content:)` so the body stays in-module and can reference the synthesized accessor. The initializer is trivial (it assigns a single closure), so the inlining benefit is negligible. The struct stays `@frozen`.

### Notes

This reproduces on a clean build against the iOS 26 SDK at v2.12.2 / `main`. No published version currently compiles against that SDK.