### PR TITLE
Solves  #125 Archiving in Xcode 27 does not work

### DIFF
--- a/Sources/Transmission/Sources/TransitionReader.swift
+++ b/Sources/Transmission/Sources/TransitionReader.swift
@@ -31,12 +31,10 @@ public struct TransitionReader<Content: View>: View {
 
     public typealias Proxy = TransitionReaderProxy
 
-    @usableFromInline
     var content: (Proxy) -> Content
 
     @State var proxy = Proxy()
 
-    @inlinable
     public init(@ViewBuilder content: @escaping (Proxy) -> Content) {
         self.content = content
     }


### PR DESCRIPTION
Solves  #125

Removes inlining tags. Not sure whether there's a better way.